### PR TITLE
fix: comments & searching (at least on ios 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 cache/
 .vscode/
 venv/
+.venv/
 .DS_Store
 .env
 *.txt

--- a/tuberepair/api/video.py
+++ b/tuberepair/api/video.py
@@ -222,7 +222,6 @@ def get_suggested(video_id, res=''):
             data = None
         else:
             data = data['recommendedVideos']
-            print(data)
         # classic tube check
         if "YouTube v1.0.0" in user_agent:
             return get.template('classic/search.jinja2',{

--- a/tuberepair/api/video.py
+++ b/tuberepair/api/video.py
@@ -156,6 +156,8 @@ def search_videos(res=''):
 # IDEA: filter the comments too?
 @video.route("/api/videos/<videoid>/comments")
 @video.route("/<int:res>/api/videos/<videoid>/comments")
+@video.route("/feeds/api/videos/<videoid>/comments")
+@video.route("/<int:res>/feeds/api/videos/<videoid>/comments")
 def comments(videoid, res=''):
     
     # Clamp Res
@@ -220,6 +222,7 @@ def get_suggested(video_id, res=''):
             data = None
         else:
             data = data['recommendedVideos']
+            print(data)
         # classic tube check
         if "YouTube v1.0.0" in user_agent:
             return get.template('classic/search.jinja2',{

--- a/tuberepair/templates/classic/search.jinja2
+++ b/tuberepair/templates/classic/search.jinja2
@@ -5,9 +5,9 @@
 <title>Videos matching:</title>  <logo>http://www.gstatic.com/youtube/img/logo.png</logo>
   <link rel="http://schemas.google.com/g/2005#feed" type="application/atom+xml" href="{{url}}/feeds/api/videos/" />
   <link rel="http://schemas.google.com/g/2005#batch" type="application/atom+xml" href="{{url}}/feeds/api/videos//batch" />
-    {% if next_page %}
-        <link rel='next' type='application/atom+xml' href='{{next_page}}'/>
-		{% endif %}
+<!--  {% if next_page %}
+    <link rel='next' type='application/atom+xml' href='{{next_page}}'/>
+	{% endif %} -->
   <author>
     <name>TubeFixer</name>
     <uri>https://tubefixer.ovh/</uri>


### PR DESCRIPTION
Decided to take a look and try to fix some problems I encountered when trying to use this.

This fixes commenting (i guess they changed the comment url from whatever phone you're testing from)
And it also fixes searching, by disabling `<link rel='next' type='application/atom+xml' href='{{next_page}}'/>`. I don't know what it's used for, but I know it breaks it.