### PR TITLE
feat: implement likes & dislikes with return youtube dislike api

### DIFF
--- a/tuberepair/modules/get.py
+++ b/tuberepair/modules/get.py
@@ -12,6 +12,10 @@ from .logs import print_with_seperator
 # cache to not spam the invidious instance
 session = CachedSession('cache/info', expire_after=timedelta(hours=1))
 
+def youtube_date(date):
+    # Opisite of the function below
+    return datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%fZ').timestamp()
+
 def unix(unix):
     return datetime.fromtimestamp(int(unix)).isoformat() + '.000Z'
 

--- a/tuberepair/templates/classic/featured.jinja2
+++ b/tuberepair/templates/classic/featured.jinja2
@@ -49,8 +49,8 @@
     <yt:accessControl action="syndicate" permission="allowed" />
     <gd:comments><gd:feedLink href='{{url}}/feeds/api/videos/{{video['videoId']}}/comments'/></gd:comments>
     <yt:statistics favoriteCount="0" viewCount="{{video['viewCount']}}" />
-<gd:rating average="5" max="5" min="1" numRaters="8101" rel="http://schemas.google.com/g/2005#overall" />
-    <yt:rating numDislikes="0" numLikes="8101" />
+<gd:rating average="5" max="5" min="1" numRaters="{{video["dislikes"] + video["likes"]}}" rel="http://schemas.google.com/g/2005#overall" />
+    <yt:rating numDislikes="{{video["dislikes"]}}" numLikes="{{video["likes"]}}" />
 <yt:hd />
     <media:group>
       <media:category label="Music" scheme="http://gdata.youtube.com/schemas/2007/categories.cat">Music</media:category>
@@ -66,8 +66,6 @@
       <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="90" width="120" yt:name="default" />
 			<media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="180" width="320" yt:name="mqdefault" />
       <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="360" width="480" yt:name="hqdefault" />
-      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="480" width="640" yt:name="sddefault" />
-      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="720" width="1280" yt:name="naxresdefault" />
       <media:title type="plain">{{video['title']}}</media:title>
       <yt:aspectRatio>widescreen</yt:aspectRatio>
       <yt:duration seconds="{{video['lengthSeconds']}}" />

--- a/tuberepair/templates/classic/search.jinja2
+++ b/tuberepair/templates/classic/search.jinja2
@@ -50,8 +50,8 @@
       <yt:accessControl action="syndicate" permission="allowed" />
       <gd:comments><gd:feedLink href='{{url}}/api/videos/{{info['videoId']}}/comments'/></gd:comments>
       <yt:statistics favoriteCount="0" viewCount="{{info['viewCount']}}" />
-  <gd:rating average="5" max="5" min="1" numRaters="15027" rel="http://schemas.google.com/g/2005#overall" />
-      <yt:rating numDislikes="0" numLikes="15027" />
+  <gd:rating average="5" max="5" min="1" numRaters="{{info['likes'] + info['dislikes']}}" rel="http://schemas.google.com/g/2005#overall" />
+      <yt:rating numDislikes="{{info['dislikes']}}" numLikes="{{info['likes']}}" />
   <yt:hd />
       <media:group>
         <media:category label="Entertainment" scheme="http://gdata.youtube.com/schemas/2007/categories.cat">Entertainment</media:category>

--- a/tuberepair/templates/featured.jinja2
+++ b/tuberepair/templates/featured.jinja2
@@ -91,7 +91,7 @@
 		<gd:rating average='0' max='0' min='0' numRaters='0' rel='https://schemas.google.com/g/2005#overall'/>
 		<yt:recorded>1970-08-22</yt:recorded>
 		<yt:statistics favoriteCount='0' viewCount="{{video['viewCount']}}"/>
-		<yt:rating numDislikes='0' numLikes='0'/>
+		<yt:rating numDislikes='{{video["dislikes"]}}' numLikes='{{video["likes"]}}'/>
 		<yt:position>1</yt:position>
 	</entry>
 {% endfor %}

--- a/tuberepair/templates/search_results.jinja2
+++ b/tuberepair/templates/search_results.jinja2
@@ -88,7 +88,7 @@
 			<gd:rating average='0' max='0' min='0' numRaters='0' rel='https://schemas.google.com/g/2005#overall'/>
 			<yt:recorded>1970-08-22</yt:recorded>
 			<yt:statistics favoriteCount='0' viewCount="{{info['viewCount']}}"/>
-			<yt:rating numDislikes='100' numLikes='10000'/>
+			<yt:rating numDislikes='{{video["dislikes"]}}' numLikes='{{video["likes"]}}'/>
 			<yt:position>1</yt:position>
 		</entry>
 	{% endfor %}


### PR DESCRIPTION
This PR implements dislikes and likes for YouTube clients thought the YouTube dislike api. I have tested it on Classic YouTube, so I might have have missed something on the app YouTube. It also fixes #15, since return YouTube dislikes api gives the date the video was created. 

I have added some fallback code if we are ratelimited, etc. Also later, it would probably be beneficial to add a way to disable this to avoid slamming the API and getting constantly limited.