### PR TITLE
Fix classic thumbnail resolution

### DIFF
--- a/tuberepair/templates/classic/featured.jinja2
+++ b/tuberepair/templates/classic/featured.jinja2
@@ -64,10 +64,10 @@
       <media:license type="text/html" href="http://www.youtube.com/t/terms">youtube</media:license>
       <media:player url="https://www.youtube.com/watch?v={{video['videoId']}}&amp;feature=youtube_gdata_player" />
       <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="90" width="120" yt:name="default" />
-			<media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="180" width="320" yt:name="mqdefault" />
-      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="360" width="480" yt:name="hqdefault" />
-      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="480" width="640" yt:name="sddefault" />
-      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/default.jpg" height="720" width="1280" yt:name="naxresdefault" />
+			<media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/mqdefault.jpg" height="180" width="320" yt:name="mqdefault" />
+      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/hqdefault.jpg" height="360" width="480" yt:name="hqdefault" />
+      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/sddefault.jpg" height="480" width="640" yt:name="sddefault" />
+      <media:thumbnail url="https://i.ytimg.com/vi/{{video['videoId']}}/maxresdefault.jpg" height="720" width="1280" yt:name="maxresdefault" />
       <media:title type="plain">{{video['title']}}</media:title>
       <yt:aspectRatio>widescreen</yt:aspectRatio>
       <yt:duration seconds="{{video['lengthSeconds']}}" />


### PR DESCRIPTION
For the classic client, the server would provide the default.jpg thumbnail for all resolutions.  This fixes that to properly map to all of the ytimg.com urls.